### PR TITLE
changing out email to be @cloud.gov

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -619,7 +619,7 @@ resources:
       username: ((smtp-username))
       password: ((smtp-password))
       ca_cert: ((smtp-certificate))
-    from: cloud-gov-no-reply@gsa.gov
+    from: cloud-gov-no-reply@cloud.gov
     to:
       - "cloud-gov-notifications@gsa.gov"
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Change out smtp from email from @gsa.gov to @cloud.gov

## security considerations
Proper SPF record setup removes chances of emails being marked spam
