### PR TITLE
2nd fix for flipping to use cg email domain

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -75,7 +75,7 @@ instance_groups:
           email_configs:
           - to: ((cg-email-address))
         smtp:
-          from: cloud-gov-no-reply@gsa.gov
+          from: cloud-gov-no-reply@cloud.gov
           smarthost: ((terraform_outputs.production_smtp_private_ip)):25
           auth_username: ((smtp-username))
           auth_password: ((smtp-password))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update 2nd part of config to use CG email domain

## security considerations
Using cloud.gov domain to match SPF records
