### PR TITLE
Convert to m6i series

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -34,7 +34,7 @@ update:
 instance_groups:
 - name: alertmanager
   instances: 1
-  vm_type: m5.large
+  vm_type: m6i.large
   persistent_disk_type: ((environment))-prometheus-small
   stemcell: default
   azs: ((azs))
@@ -85,7 +85,7 @@ instance_groups:
 
 - name: prometheus
   instances: 1
-  vm_type: m5.2xlarge
+  vm_type: m6i.2xlarge
   persistent_disk_type: ((environment))-prometheus-large
   stemcell: default
   azs: ((azs))
@@ -290,7 +290,7 @@ instance_groups:
 
 - name: grafana
   instances: 1
-  vm_type: m5.large
+  vm_type: m6i.large
   persistent_disk_type: ((environment))-prometheus-small
   stemcell: default
   azs: ((azs))

--- a/bosh/opsfiles/prod-common.yml
+++ b/bosh/opsfiles/prod-common.yml
@@ -106,7 +106,7 @@
 # instance types.
 - type: replace
   path: /instance_groups/name=prometheus/vm_type
-  value: m5.xlarge
+  value: m6i.xlarge
 - type: replace
   path: /instance_groups/name=prometheus-tooling/vm_type
-  value: m5.large
+  value: m6i.large

--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -106,10 +106,10 @@
 # instance types.
 - type: replace
   path: /instance_groups/name=prometheus/vm_type
-  value: m5.xlarge
+  value: m6i.xlarge
 - type: replace
   path: /instance_groups/name=prometheus-tooling/vm_type
-  value: m5.large
+  value: m6i.large
 
 # add some prod-only rules
 # monitor Pages proxy

--- a/bosh/opsfiles/staging.yml
+++ b/bosh/opsfiles/staging.yml
@@ -1,6 +1,6 @@
 - type: replace
   path: /instance_groups/name=prometheus/vm_type
-  value: m5.large
+  value: m6i.large
 
 - type: replace
   path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules/name=networker/rules/alert=NetworkTrafficBurst/for?


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove m5 usage, discovered during AWS pricing session
- https://github.com/cloud-gov/private/issues/618
-

## security considerations
None, just changing vm instance classes
