### PR TITLE
Set newborn RDS freespace to 10GB to prevent false alerts

### DIFF
--- a/ci/aws-rds-storage/rds_disk_space.py
+++ b/ci/aws-rds-storage/rds_disk_space.py
@@ -41,8 +41,8 @@ def get_free_space(db_instance):
     try:
         free_space = min([(lambda x: x['Average'])(datapoint) for datapoint in cloudtrail_response['Datapoints']])
     except:
-        # Probably a new born db, could not pull cloudwatch metrics, setting value to 100000000
-        free_space = 100000000
+        # Probably a new born db, could not pull cloudwatch metrics, setting value to 10000000000 (10GB) as minimum size is 20GB
+        free_space = 10000000000
         
     return free_space
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- This is an update to an earlier patch to handle the RDS storage check job from failing on a new RDS instance that was alive but had not yet had time to report any data to CloudWatch.  While the original patch keeps the Python from erroring out it has the byproduct of for the first 30 minutes showing the RDS instance using up more than 88% of disk because the catch sets the value to only 0.1GB.  This fixes that "first time seen" problem and satisfies the storage calculation by setting the value to 10GB.
- Part of Platform maintenance: https://github.com/cloud-gov/private/issues/618
-

## security considerations
Should be preventing false Prometheus alerts 
