### PR TITLE
Adding wildcard for new releases

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -398,7 +398,7 @@ jobs:
           cert: master-bosh-root-cert/master-bosh.crt
           manifest: prometheus-config/bosh/manifest.yml
           releases:
-            - prometheus-release/*.tgz
+            - prometheus-release/*.*gz*
             - oauth2-proxy-release/*.tgz
             - secureproxy-release/*.tgz
           stemcells:


### PR DESCRIPTION
## Changes proposed in this pull request:
- The Prometheus team is releasing new versions as `.tgz` and `tar.gz` versions so the pipeline needs to adjust file filter

## security considerations
N/A