### PR TITLE
add prometheus alerts for OpenSearch node disk usage

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -455,7 +455,7 @@
     name: opensearch
     rules:
     - alert: opensearch_disk_critical
-      expr: bosh_job_persistent_disk_percent{bosh_deployment="logs-opensearch"} > 85
+      expr: bosh_job_persistent_disk_percent{bosh_deployment="logs-opensearch"} > 82
       for: 30m
       labels:
         service: opensearch
@@ -464,7 +464,7 @@
         summary: "opensearch node {{$labels.bosh_job_name}}/{{$labels.bosh_job_id}} index {{$labels.bosh_job_index}} disk is over 85% used"
         description: Review deployment and indexes and see if index and/or scaling operations need to take place for growth
     - alert: opensearch_disk_warning
-      expr: bosh_job_persistent_disk_percent{bosh_deployment="logs-opensearch"} > 88
+      expr: bosh_job_persistent_disk_percent{bosh_deployment="logs-opensearch"} > 85
       for: 5m
       labels:
         service: opensearch

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -447,3 +447,28 @@
       annotations:
         summary: Uptime check failed (non-200 response) for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}}
         description: Uptime check failed (non-200 response) for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}}. Runbook - https://github.com/cloud-gov/internal-docs/blob/main/docs/runbooks/Metrics-and-Alerting/uptime-monitoring.md#uptimemonitorfailed
+
+# opensearch disk alerts
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: opensearch
+    rules:
+    - alert: opensearch_disk_critical
+      expr: bosh_job_persistent_disk_percent{bosh_deployment="logs-opensearch"} > 85
+      for: 30m
+      labels:
+        service: opensearch
+        severity: critical
+      annotations:
+        summary: "opensearch node {{$labels.bosh_job_name}}/{{$labels.bosh_job_id}} index {{$labels.bosh_job_index}} disk is over 85% used"
+        description: Review deployment and indexes and see if index and/or scaling operations need to take place for growth
+    - alert: opensearch_disk_warning
+      expr: bosh_job_persistent_disk_percent{bosh_deployment="logs-opensearch"} > 88
+      for: 5m
+      labels:
+        service: opensearch
+        severity: warning
+      annotations:
+        summary: "opensearch node {{$labels.bosh_job_name}}/{{$labels.bosh_job_id}} index {{$labels.bosh_job_index}} disk is over 88% used"
+        description: Review deployment and indexes and see if index and/or scaling operations need to take place for growth


### PR DESCRIPTION
## Changes proposed in this pull request:

Closes https://github.com/cloud-gov/private/issues/2449

This PR adds Prometheus alerts to detect when OpenSearch node persistent disk usage reaches dangerous levels that could compromise the health of the service. The threshold of 82% for critical alerts was chosen because it is close the setting we have for the [low-disk watermark in OpenSearch](https://docs.opensearch.org/docs/latest/install-and-configure/configuring-opensearch/cluster-settings/), but should give us enough time to react before the cluster health is in danger.

## security considerations

None. This configuration is not sensitive
