### PR TITLE
Split prometheus-tooling to its own disk

### DIFF
--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -22,7 +22,7 @@
     name: prometheus-tooling
     instances: 1
     vm_type: ((environment))-prometheus-large
-    persistent_disk_type: ((environment))-prometheus-large
+    persistent_disk_type: ((environment))-prometheus-tooling
     stemcell: default
     azs: ((azs))
     networks:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switches disk size and type for prometheus-tooling vm in prod to significantly cheaper gp3 disk and smaller volume size
- Part of https://github.com/cloud-gov/private/issues/2594
-

## security considerations
None.  Switches disk size and type for prometheus-tooling vm in prod
