### PR TITLE
Adjusting prod blackbox monitor list

### DIFF
--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -18,7 +18,6 @@ blackbox-targets:
 - https://test-php.app.cloud.gov
 - https://test-ruby-padrino.app.cloud.gov
 - https://test-ruby-sinatra.app.cloud.gov
-- https://www.fdic.gov
 - https://www.fec.gov
 - https://api.data.gov
 - https://fire.airnow.gov


### PR DESCRIPTION
## Changes proposed in this pull request:
- Since www.fdic.gov moved off platform and cert gen is not under our control, removing it from BlackBox

## security considerations
n/a
