### PR TITLE
Update staging to support UAA group membership for role mapping

### DIFF
--- a/bosh/opsfiles/staging.yml
+++ b/bosh/opsfiles/staging.yml
@@ -8,3 +8,63 @@
 - type: replace
   path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules/name=networker/rules/alert=LargeNetworkTrafficBurst/for?
   value: 5m
+
+
+# Configure Grafana to use UAA authentication
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/generic_oauth
+  value:
+    enabled: true
+    name: "Cloud.gov Operator Opslogin"
+    allow_sign_up: true
+    client_id: prometheus-staging
+    client_secret: ((oauth-proxy-client-secret))
+    auth_url: https://opslogin.fr.cloud.gov/oauth/authorize
+    token_url: https://opslogin.fr.cloud.gov/oauth/token
+    api_url: https://opslogin.fr.cloud.gov/userinfo
+    tls_client_ca: ((lets_encrypt_ca.certificate))
+    tls_client_cert: ((/toolingbosh/opsuaa/uaa_ssl.certificate))
+    tls_client_key: ((/toolingbosh/opsuaa/uaa_ssl.private_key))
+    tls_skip_verify_insecure: false
+    auto_login: true
+
+    # Map UAA groups to Grafana roles based on .admin or .support suffix 
+    # Do not make this a multiline string, grafana.ini errors reading it, values MUST be in single quotes or the mapping silently fails
+    role_attribute_path: contains(scope[*], 'grafana_platform.admin') && 'GrafanaAdmin' || contains(scope[*], 'grafana_pages.admin') && 'Admin' || contains(scope[*], 'grafana_workshop.admin') && 'Admin' || contains(scope[*], 'grafana_notify.admin') && 'Admin' || contains(scope[*], 'grafana_platform.support') && 'Viewer' || contains(scope[*], 'grafana_pages.support') && 'Viewer' || contains(scope[*], 'grafana_workshop.support') && 'Viewer' || contains(scope[*], 'grafana_notify.support') && 'Viewer' || 'Viewer'
+
+    # This list must be inclusive of all the UAA groups that you want to map, if not, role_attribute_path will map everyone as a Viewer
+    # This is the same list of scopes that has to be defined on the prometheus-staging UAA client, otherwise you will get a "failed to login" in grafana
+    scopes: openid profile email grafana_platform.admin grafana_platform.support grafana_pages.admin grafana_pages.support grafana_workshop.admin grafana_workshop.support grafana_notify.admin grafana_notify.support
+
+    # This is the name of the array field in the id_token/access_token to map to.  
+    groups_attribute_path: scope
+
+    # Needed for the role of GrafanaAdmin to be assigned
+    allow_assign_grafana_admin: true
+
+    # Match order is id_token, userinfo, access_token.  This overrides to force the access_token which has the scopes, to be first.  The scope in id_token only has "openid", the scope in access_token has all the group memberships so the access_token is the desired one.
+    id_token_attribute_name: access_token
+
+# Enable users auto-assignment
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/users?/auto_assign_org
+  value: true
+
+# There is only 1 org
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/users?/auto_assign_org_id
+  value: 1
+
+# Configure auth settings
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/disable_login_form
+  value: false
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/oauth_auto_login
+  value: true
+
+# Turn on basic auth for API access from the grafana vm itself
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/basic?/enabled
+  value: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- Configuration allows for UAA group mappings in OpsUAA to align with Grafana roles, just in staging
- Deploy should be a no-op, the changes have already been ad-hoc applied to staging
- Part of https://github.com/cloud-gov/private/issues/2635 
-

## security considerations
This is for staging only.  While basic auth is enabled, it is only accessible for the Grafana API while ssh'd onto the grafana vm.
